### PR TITLE
Update Go to Use New Uploader

### DIFF
--- a/.github/workflows/go-standard.yml
+++ b/.github/workflows/go-standard.yml
@@ -1,11 +1,11 @@
 name: Github Actions Go Standard
-on: [push]
-  # push:
-  #   branches:
-  #     - master
-  # pull_request:
-  #   branches:
-  #     - master
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   test-and-upstream:
     runs-on: ubuntu-latest
@@ -35,13 +35,13 @@ jobs:
           chmod +x codecov
           ./codecov -t ${CODECOV_TOKEN}
           python request.py
-      # - name: Upstream to Standards
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      #     COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
-      #   if: ${{ github.event_name == 'push'}}
-      #   run: |
-      #     wget --header "Authorization: token ${GH_TOKEN}" \
-      #     --header "Accept: application/vnd.github.v3.raw" \
-      #     https://api.github.com/repos/codecov/standards/contents/upstream.sh
-      #     bash upstream.sh
+      - name: Upstream to Standards
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
+        if: ${{ github.event_name == 'push'}}
+        run: |
+          wget --header "Authorization: token ${GH_TOKEN}" \
+          --header "Accept: application/vnd.github.v3.raw" \
+          https://api.github.com/repos/codecov/standards/contents/upstream.sh
+          bash upstream.sh

--- a/.github/workflows/go-standard.yml
+++ b/.github/workflows/go-standard.yml
@@ -1,11 +1,11 @@
 name: Github Actions Go Standard
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push]
+  # push:
+  #   branches:
+  #     - master
+  # pull_request:
+  #   branches:
+  #     - master
 jobs:
   test-and-upstream:
     runs-on: ubuntu-latest
@@ -31,15 +31,17 @@ jobs:
           EXPECTED_COVERAGE: ${{ secrets.EXPECTED_COVERAGE }}
         run: |
           go test -race -coverprofile=coverage.txt -covermode=atomic
-          bash <(curl -s https://codecov.io/bash)
+          curl -Os https://uploader.codecov.io/latest/alpine/codecov
+          chmod +x codecov
+          ./codecov -t ${CODECOV_TOKEN}
           python request.py
-      - name: Upstream to Standards
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
-        if: ${{ github.event_name == 'push'}}
-        run: |
-          wget --header "Authorization: token ${GH_TOKEN}" \
-          --header "Accept: application/vnd.github.v3.raw" \
-          https://api.github.com/repos/codecov/standards/contents/upstream.sh
-          bash upstream.sh
+      # - name: Upstream to Standards
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      #     COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
+      #   if: ${{ github.event_name == 'push'}}
+      #   run: |
+      #     wget --header "Authorization: token ${GH_TOKEN}" \
+      #     --header "Accept: application/vnd.github.v3.raw" \
+      #     https://api.github.com/repos/codecov/standards/contents/upstream.sh
+      #     bash upstream.sh

--- a/.github/workflows/go-standard.yml
+++ b/.github/workflows/go-standard.yml
@@ -31,7 +31,7 @@ jobs:
           EXPECTED_COVERAGE: ${{ secrets.EXPECTED_COVERAGE }}
         run: |
           go test -race -coverprofile=coverage.txt -covermode=atomic
-          curl -Os https://uploader.codecov.io/latest/alpine/codecov
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
           ./codecov -t ${CODECOV_TOKEN}
           python request.py

--- a/request.py
+++ b/request.py
@@ -20,7 +20,7 @@ commit_data = all_data['commits'][0]
 coverage_percentage = commit_data['totals']['c']
 
 print("Ensuring coverage percentage is accurate...")
-# Result should return 62.50000 as its coverage metric
+# Result should return 66.66667 as its coverage metric
 expected_coverage = os.environ['EXPECTED_COVERAGE']
 
 if(coverage_percentage == expected_coverage): 


### PR DESCRIPTION
This PR is to update the Go Standard to use the new uploader. It was discovered that updating the uploader in this repo had effects on the coverage it yields, hence this ticket. 

As part of this effort, I would need someone with right permissions to change the `EXPECTED_COVERAGE` env variable for this repo to `66.66667` as that is the new expected coverage, allowing the GHA to pass successfully as it should.